### PR TITLE
Added web safe font mode

### DIFF
--- a/OpenXmlToHtml/IOpenXmlToHtml.cs
+++ b/OpenXmlToHtml/IOpenXmlToHtml.cs
@@ -13,22 +13,25 @@ namespace Codeuctivity.OpenXmlToHtml
         /// </summary>
         /// <param name="sourceOpenXmlFilePath"></param>
         /// <param name="destinationHtmlFilePath"></param>
+        /// <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
         /// <returns>selfContainedHtmlFilePath</returns>
-        Task ConvertToHtmlAsync(string sourceOpenXmlFilePath, string destinationHtmlFilePath);
+        Task ConvertToHtmlAsync(string sourceOpenXmlFilePath, string destinationHtmlFilePath, bool useWebSafeFonts = false);
 
         /// <summary>
         /// Converts DOCX to HTML
         /// </summary>
         /// <param name="sourceOpenXml"></param>
+        /// <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
         /// <returns>selfContainedHtml</returns>
-        Task<Stream> ConvertToHtmlAsync(Stream sourceOpenXml);
+        Task<Stream> ConvertToHtmlAsync(Stream sourceOpenXml, bool useWebSafeFonts = false);
 
         /// <summary>
         /// Converts DOCX to HTML
         /// </summary>
         /// <param name="sourceOpenXml"></param>
         /// <param name="fallbackPageTitle"></param>
+        /// <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
         /// <returns>selfContainedHtml</returns>
-        Task<Stream> ConvertToHtmlAsync(Stream sourceOpenXml, string fallbackPageTitle);
+        Task<Stream> ConvertToHtmlAsync(Stream sourceOpenXml, string fallbackPageTitle, bool useWebSafeFonts = false);
     }
 }

--- a/OpenXmlToHtml/OpenXmlToHtml.csproj
+++ b/OpenXmlToHtml/OpenXmlToHtml.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="OpenXmlPowerToolsStandard" Version="5.0.92" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OpenXmlToHtml/OpenXmlToHtml.csproj
+++ b/OpenXmlToHtml/OpenXmlToHtml.csproj
@@ -24,7 +24,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <PackageId>OpenXmlToHtml</PackageId>
     <Product>OpenXmlToHtml</Product>
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="OpenXmlPowerToolsStandard" Version="5.0.92" />
+    <PackageReference Include="OpenXmlPowerToolsStandard" Version="5.0.99-prerelease" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenXmlToHtml/WebSafeFontsHandler.cs
+++ b/OpenXmlToHtml/WebSafeFontsHandler.cs
@@ -1,0 +1,52 @@
+﻿using OpenXmlPowerTools.OpenXMLWordprocessingMLToHtmlConverter;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Codeuctivity.OpenXmlToHtml
+{
+    public class WebSafeFontsHandler : IFontHandler
+    {
+        /// <summary>
+        /// Best Web Safe Fonts for HTML and CSS https://www.w3schools.com/cssref/css_websafe_fonts.asp
+        /// </summary>
+        public string[] WebSafeFontNames { get; private set; }
+
+        public FontHandler FontHandler { get; }
+
+        public WebSafeFontsHandler()
+        {
+            WebSafeFontNames = new string[] { "Arial", "Verdana", "Helvetica", "Tahoma", "Trebuchet MS", "Times New Roman", "Georgia", "Garamond", "Courier New", "Brush Script MT" };
+            FontHandler = new FontHandler();
+        }
+
+        public WebSafeFontsHandler(string[] webSafeFontNames)
+        {
+            WebSafeFontNames = webSafeFontNames;
+            FontHandler = new FontHandler();
+        }
+
+        public string TranslateParagraphStyleFont(XElement paragraph)
+        {
+            var unsafeFont = FontHandler.TranslateParagraphStyleFont(paragraph);
+
+            return tranlateToWebSafeFont(unsafeFont);
+        }
+
+        public string TranslateRunStyleFont(XElement run)
+        {
+            var unsafeFont = FontHandler.TranslateRunStyleFont(run);
+
+            return tranlateToWebSafeFont(unsafeFont);
+        }
+
+        private string tranlateToWebSafeFont(string unsafeFont)
+        {
+            if (WebSafeFontNames.Contains(unsafeFont))
+            {
+                return unsafeFont;
+            }
+
+            return "Arial";
+        }
+    }
+}

--- a/OpenXmlToHtmlCli/OpenXmlToHtmlCli.csproj
+++ b/OpenXmlToHtmlCli/OpenXmlToHtmlCli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
      <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OpenXmlToHtmlOpenApi/Controllers/OpenXmlConverterController.cs
+++ b/OpenXmlToHtmlOpenApi/Controllers/OpenXmlConverterController.cs
@@ -30,15 +30,16 @@ namespace OpenXmlToHtmlOpenApi.Controllers
         /// Converts OpenXmlFile to HTML
         /// </summary>
         /// <param name="openXmlFile"></param>
+        /// <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
         /// <returns>HTML</returns>
         [HttpPost]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
-        public async Task<IActionResult> ConvertToHtml(IFormFile openXmlFile)
+        public async Task<IActionResult> ConvertToHtml(IFormFile openXmlFile, bool useWebSafeFonts)
         {
             if (openXmlFile.Length > 0)
             {
-                var htmlStream = await _openXmlToHtml.ConvertToHtmlAsync(openXmlFile.OpenReadStream());
+                var htmlStream = await _openXmlToHtml.ConvertToHtmlAsync(openXmlFile.OpenReadStream(), useWebSafeFonts);
                 return File(htmlStream, "text/html");
             }
             return BadRequest("Request contains no document");
@@ -48,12 +49,13 @@ namespace OpenXmlToHtmlOpenApi.Controllers
         /// Converts OpenXmlFile to PDF
         /// </summary>
         /// <param name="openXmlFile"></param>
+        /// <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
         /// <returns>PDF</returns>
         [HttpPost]
         [Route("ConvertToPdf")]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
-        public async Task<IActionResult> ConvertToPdf(IFormFile openXmlFile)
+        public async Task<IActionResult> ConvertToPdf(IFormFile openXmlFile, bool useWebSafeFonts)
         {
             await using var chromiumRenderer = await Renderer.CreateAsync();
             if (openXmlFile.Length > 0)
@@ -61,7 +63,7 @@ namespace OpenXmlToHtmlOpenApi.Controllers
                 var pathHtml = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.html");
                 var pathPdf = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.pdf");
 
-                var htmlStream = await _openXmlToHtml.ConvertToHtmlAsync(openXmlFile.OpenReadStream());
+                var htmlStream = await _openXmlToHtml.ConvertToHtmlAsync(openXmlFile.OpenReadStream(), useWebSafeFonts);
                 try
                 {
                     using var fileStreamHtml = new FileStream(pathHtml, FileMode.CreateNew);

--- a/OpenXmlToHtmlOpenApi/OpenXmlToHtmlOpenApi/OpenXmlToHtmlOpenApi.xml
+++ b/OpenXmlToHtmlOpenApi/OpenXmlToHtmlOpenApi/OpenXmlToHtmlOpenApi.xml
@@ -15,18 +15,20 @@
             </summary>
             <param name="openXmlToHtml"></param>
         </member>
-        <member name="M:OpenXmlToHtmlOpenApi.Controllers.OpenXmlConverterController.ConvertToHtml(Microsoft.AspNetCore.Http.IFormFile)">
+        <member name="M:OpenXmlToHtmlOpenApi.Controllers.OpenXmlConverterController.ConvertToHtml(Microsoft.AspNetCore.Http.IFormFile,System.Boolean)">
             <summary>
             Converts OpenXmlFile to HTML
             </summary>
             <param name="openXmlFile"></param>
+            <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
             <returns>HTML</returns>
         </member>
-        <member name="M:OpenXmlToHtmlOpenApi.Controllers.OpenXmlConverterController.ConvertToPdf(Microsoft.AspNetCore.Http.IFormFile)">
+        <member name="M:OpenXmlToHtmlOpenApi.Controllers.OpenXmlConverterController.ConvertToPdf(Microsoft.AspNetCore.Http.IFormFile,System.Boolean)">
             <summary>
             Converts OpenXmlFile to PDF
             </summary>
             <param name="openXmlFile"></param>
+            <param name="useWebSafeFonts">Use 'true' to replace every non web safe font with some fallback. Default is false.</param>
             <returns>PDF</returns>
         </member>
         <member name="T:OpenXmlToHtmlOpenApi.Program">

--- a/OpenXmlToHtmlOpenApiTests/OpenXmlToHtmlOpenApiTests.csproj
+++ b/OpenXmlToHtmlOpenApiTests/OpenXmlToHtmlOpenApiTests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.15.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="AngleSharp" Version="0.16.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/OpenXmlToHtmlTests/OpenXmlToHtmlIntegrationTests.cs
+++ b/OpenXmlToHtmlTests/OpenXmlToHtmlIntegrationTests.cs
@@ -55,7 +55,7 @@ namespace OpenXmlToHtmlTests
             using var sourceIpenXml = new FileStream(sourceOpenXmlFilePath, FileMode.Open, FileAccess.Read);
             var exportedImages = new Dictionary<string, byte[]>();
 
-            var actuelHtml = await OpenXmlToHtml.ConvertToHtmlAsync(sourceIpenXml, "fallbackTitle", exportedImages);
+            var actuelHtml = await OpenXmlToHtml.ConvertToHtmlAsync(sourceIpenXml, "fallbackTitle", exportedImages, false);
 
             Assert.Equal(2, exportedImages.Count);
 

--- a/OpenXmlToHtmlTests/OpenXmlToHtmlTests.csproj
+++ b/OpenXmlToHtmlTests/OpenXmlToHtmlTests.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="PdfSharp.netstandard" Version="1.3.2" />
     <PackageReference Include="PuppeteerSharp.Renderer" Version="1.1.32" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenXmlToHtmlTests/OpenXmlToHtmlTests.csproj
+++ b/OpenXmlToHtmlTests/OpenXmlToHtmlTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/OpenXmlToHtmlTests/WebSafeFontsHandlerTests.cs
+++ b/OpenXmlToHtmlTests/WebSafeFontsHandlerTests.cs
@@ -1,0 +1,46 @@
+﻿using Codeuctivity.OpenXmlToHtml;
+using OpenXmlPowerTools;
+using System.Xml.Linq;
+using Xunit;
+
+namespace OpenXmlToHtmlTests
+{
+    public class WebSafeFontsHandlerTests
+    {
+        [Fact]
+        public void ShouldTranslateFontInRunSymbolWithFontHandler()
+        {
+            var fontHandler = new WebSafeFontsHandler();
+
+            var element = new XElement("run", new XElement(W.sym, new XAttribute(W.font, "SomeBadSymbolFont")), new XAttribute(PtOpenXml.FontName, "SomeBadRunFont"));
+
+            var actual = fontHandler.TranslateRunStyleFont(element);
+
+            Assert.Equal("Arial", actual);
+        }
+
+        [Fact]
+        public void ShouldTranslateFontInRunWithFontHandler()
+        {
+            var fontHandler = new WebSafeFontsHandler();
+
+            var element = new XElement("run", new XAttribute(PtOpenXml.FontName, "SomeBadRunFont"));
+
+            var actual = fontHandler.TranslateRunStyleFont(element);
+
+            Assert.Equal("Arial", actual);
+        }
+
+        [Fact]
+        public void ShouldTranslateFontInParagraphWithFontHandler()
+        {
+            var fontHandler = new WebSafeFontsHandler();
+
+            var element = new XElement("run", new XAttribute(PtOpenXml.FontName, "SomeBadRunFont"));
+
+            var actual = fontHandler.TranslateParagraphStyleFont(element);
+
+            Assert.Equal("Arial", actual);
+        }
+    }
+}


### PR DESCRIPTION
If useWebSafeFonts is set to true, every font excpet these get replaced with arial:
"Arial", "Verdana", "Helvetica", "Tahoma", "Trebuchet MS", "Times New Roman", "Georgia", "Garamond", "Courier New", "Brush Script MT"